### PR TITLE
Fix cutting an empty selection on the last line

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,7 +1,7 @@
 on:
   push:
-    branches:
-      - master
+    branches: [master]
+  pull_request:
 
 jobs:
   build:

--- a/src/test/extension.test.ts
+++ b/src/test/extension.test.ts
@@ -9,15 +9,19 @@ async function runCopyPaste(
     const document = await vscode.workspace.openTextDocument({ content: input });
     const editor = await vscode.window.showTextDocument(document);
 
-    editor.selections = copySelections;
-    if (cut) {
-        await vscode.commands.executeCommand('better-copy-paste.cut');
-    } else {
-        await vscode.commands.executeCommand('better-copy-paste.copy');
+    if (copySelections.length > 0) {
+        editor.selections = copySelections;
+        if (cut) {
+            await vscode.commands.executeCommand('better-copy-paste.cut');
+        } else {
+            await vscode.commands.executeCommand('better-copy-paste.copy');
+        }
     }
 
-    editor.selections = pasteSelections;
-    await vscode.commands.executeCommand('better-copy-paste.paste');
+    if (pasteSelections.length > 0) {
+        editor.selections = pasteSelections;
+        await vscode.commands.executeCommand('better-copy-paste.paste');
+    }
 
     return document.getText();
 }
@@ -135,6 +139,22 @@ suite("Extension Test Suite", () => {
             'hello',
             '',
             '    world',
+        ].join("\n");
+
+        assert.strictEqual(output, expectedOutput);
+    });
+
+    test("Cut last line empty selection", async () => {
+        const input = [
+            'hello world',
+            '',
+        ].join("\n");
+
+        const output = await runCopyPaste(
+            input, [new vscode.Selection(1, 0, 1, 0)], [], true
+        );
+        const expectedOutput = [
+            'hello world',
         ].join("\n");
 
         assert.strictEqual(output, expectedOutput);


### PR DESCRIPTION
Cutting an empty selection cuts the current line including it's EOL characters. The last line, by definition, will not contain EOL characters. VSCode's stock behavior seems to be to delete the previous line's EOL characters in this case, so that the line still appears to the user to be deleted.

Fixes #1 